### PR TITLE
Integrate the CI for continous deployment to pub.dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## 0.2.0
+## 1.0.0
+
+- First stable deployment.
+
+## 0.2.1
+
+- Setup CI pipeline for deployment to dart pub hub.
+
+## 0.0.1
 
 - Implementing `RequestsSignatureInterceptor`.
-- Setup CI pipeline for deployment to dart pub hub.
+- Setup CI pipeline for validating that changes are valid.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # RequestsSignature-Dart
 
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=flat-square)](LICENSE) [![Pub Package](https://img.shields.io/pub/v/requests_signature_dart.svg?style=flat-square)](https://pub.dartlang.org/packages/requests_signature_dart) [![package publisher](https://img.shields.io/pub/publisher/requests_signature_dart.svg?style=flat-square)](https://pub.dev/packages/requests_signature_dart/publisher)
+
 Signs and validates HTTP requests.
 
 This projects can help you implements [HMAC](https://en.wikipedia.org/wiki/HMAC) signature to HTTP requests on flutter projects.
-
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 ## Getting Started
 
@@ -28,6 +28,7 @@ Then do the following to add a `RequestsSignatureInterceptor` to your Dio client
 
 ```dart
 import 'package:requests_signature_dart/requests_signature_dart.dart';
+import 'package:requests_signature_dart/src/client/requests_signature_options.dart';
 import 'package:dio/dio.dart';
 
 void main() {

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,6 +7,10 @@ pr:
     include:
       - main
 
+variables:
+- name: IsReleaseBranch # Should this branch name use the release stage
+  value: $[eq(variables['Build.SourceBranch'], 'refs/heads/main')]
+  
 pool:
   vmImage: ubuntu-20.04
 
@@ -46,10 +50,19 @@ steps:
 - script: flutter pub publish --dry-run
   displayName: 'Run flutter pub publish --dry-run'
 
+- task: DownloadSecureFile@1
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['IsReleaseBranch'], 'true'))
+  inputs:
+    secureFile: 'flutter_publisher_gckey.json'
+  name: DownloadGCloudKey
 
+- script: | 
+    gcloud auth activate-service-account --key-file=$(DownloadGCloudKey.secureFilePath)
+    gcloud auth print-identity-token --audiences=https://pub.dev | dart pub token add https://pub.dev
+    dart pub publish --force
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['IsReleaseBranch'], 'true'))
+  displayName: 'Publish to pub.dev as a nventive publisher'
 
-
-
-  
-
-
+- task: PostBuildCleanup@3
+  displayName: 'Post-Build Cleanup: Cleanup files to keep build server clean!'
+  condition: always()

--- a/example/example.dart
+++ b/example/example.dart
@@ -1,0 +1,31 @@
+import 'package:requests_signature_dart/requests_signature_dart.dart';
+import 'package:requests_signature_dart/src/client/requests_signature_options.dart';
+import 'package:dio/dio.dart';
+
+void main() {
+  // Instantiate Dio client.
+  final dio = Dio();
+
+  // Define signature options.
+  final signatureOptions = RequestsSignatureOptions(
+    clientId: 'your_client_id', // Your unique client ID
+    clientSecret: 'your_client_secret', // Your client secret key
+    headerName:
+        'X-Request-Signature', // Name of the custom header for the signature
+    signaturePattern:
+        '{ClientId}:{Nonce}:{Timestamp}:{SignatureBody}', // Pattern for the signature header value
+    clockSkew: Duration(
+        seconds: 30), // Clock skew duration (30 seconds in this example)
+    disableAutoRetryOnClockSkew:
+        false, // Disable auto retry on clock skew if set to true
+  );
+
+  // Instantiate interceptor.
+  final interceptor = RequestsSignatureInterceptor(
+    signatureOptions,
+    dio,
+  );
+
+  // Add interceptor to Dio client.
+  dio.interceptors.add(interceptor);
+}

--- a/lib/src/client/dio_interceptor.dart
+++ b/lib/src/client/dio_interceptor.dart
@@ -32,6 +32,8 @@ class RequestsSignatureInterceptor extends Interceptor {
   ///
   /// Optionally, you can provide custom implementations for
   /// [signatureBodySourceBuilder] and [signatureBodySigner].
+  ///
+  /// Optionally, you can provide a custom logic to get the current time via [getTime].
   RequestsSignatureInterceptor(
     this._options,
     this._dioInstance, {

--- a/lib/src/core/exception/requests_signature_exception.dart
+++ b/lib/src/core/exception/requests_signature_exception.dart
@@ -1,6 +1,9 @@
+/// Exceptions thrown during Requests Signature processing.
 class RequestsSignatureException implements Exception {
+  /// Message to display when this exception is raised.
   final String message;
 
+  /// Constructs a new [RequestsSignatureException] with a given [message].
   RequestsSignatureException(this.message);
 
   @override

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,38 +41,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
-  build:
-    dependency: transitive
-    description:
-      name: build
-      sha256: "80184af8b6cb3e5c1c4ec6d8544d27711700bc3e6d2efad04238c7b5290889f0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.1"
-  built_collection:
-    dependency: transitive
-    description:
-      name: built_collection
-      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.1.1"
-  built_value:
-    dependency: transitive
-    description:
-      name: built_value
-      sha256: c7913a9737ee4007efedaffc968c049fd0f3d0e49109e778edc10de9426005cb
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.9.2"
-  code_builder:
-    dependency: transitive
-    description:
-      name: code_builder
-      sha256: f692079e25e7869c14132d39f223f8eec9830eb76131925143b2129c4bb01b37
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.10.0"
   collection:
     dependency: transitive
     description:
@@ -113,14 +81,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.7.0"
-  dart_style:
-    dependency: transitive
-    description:
-      name: dart_style
-      sha256: "99e066ce75c89d6b29903d788a7bb9369cf754f7b24bf70bf4b6d6d6b26853b9"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.6"
   dio:
     dependency: "direct main"
     description:
@@ -178,7 +138,7 @@ packages:
     source: hosted
     version: "1.2.1"
   http_mock_adapter:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: http_mock_adapter
       sha256: "46399c78bd4a0af071978edd8c502d7aeeed73b5fb9860bca86b5ed647a63c1b"
@@ -257,14 +217,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
-  mockito:
-    dependency: "direct main"
-    description:
-      name: mockito
-      sha256: "6841eed20a7befac0ce07df8116c8b8233ed1f4486a7647c7fc5a02ae6163917"
-      url: "https://pub.dev"
-    source: hosted
-    version: "5.4.4"
   node_preamble:
     dependency: transitive
     description:
@@ -337,14 +289,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
-  source_gen:
-    dependency: transitive
-    description:
-      name: source_gen
-      sha256: "14658ba5f669685cd3d63701d01b31ea748310f7ab854e471962670abcf57832"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.5.0"
   source_map_stack_trace:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,6 +2,8 @@ name: requests_signature_dart
 description: "A Dart package for making HTTP requests with cryptographic signatures."
 version: 0.9.9 # The version will be overriden in the CI following semantic versioning.
 homepage: https://github.com/nventive/RequestsSignature-Dart
+repository: https://github.com/nventive/RequestsSignature-Dart
+issue_tracker: https://github.com/nventive/RequestsSignature-Dart/issues
 
 environment:
   sdk: '>=2.12.0 <4.0.0'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,11 +11,10 @@ dependencies:
   cryptography: ^2.7.0
   dio: ^5.4.1
   http: ^1.2.0
-  mockito: ^5.4.4
-  http_mock_adapter: ^0.6.1
   uuid: ^4.3.3
 
 dev_dependencies:
   test: ^1.25.2
+  http_mock_adapter: ^0.6.1
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [x] Build or CI related changes
 - [ ] Documentation content changes
 - [ ] Other, please describe:


## What is the current behavior?
The CI is currently not set up to deploy automatically to pub.dev.

## What is the new behavior?
The CI is configured to deploy to pub.dev as nventive publisher only when triggered from main.

## Checklist

Please check that your PR fulfills the following requirements:

- [x] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [x] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

