### PR TITLE
ci: update pr template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,4 @@
 GitHub Issue: #
-<!-- Link to relevant GitHub issue if applicable.
-     All PRs should be associated with an issue -->
 
 ## Proposed Changes
 <!-- Please check one or more that apply to this PR. -->
@@ -13,27 +11,40 @@ GitHub Issue: #
  - [ ] Documentation content changes
  - [ ] Other, please describe:
 
+## Description
 
-## What is the current behavior?
-<!-- Please describe the current behavior that you are modifying,
-     or link to a relevant issue. -->
-
-
-## What is the new behavior?
-<!-- Please describe the new behavior after your modifications. -->
+<!-- Please describe the changes that this PR introduces. -->
 
 
-## Checklist
+## Impact on version
+<!-- Please select one or more based on your commits. -->
 
-Please check that your PR fulfills the following requirements:
+- [ ] **Major** (Public API was modified.)
+  - Public constructs (class, struct, delegate, enum, etc.) were removed or renamed.
+  - Public members were removed or renamed.
+  - Public method signatures were changed or renamed.
+- [ ] **Minor** (Public API was extended.)
+  - Public constructs, members, or overloads were added.
+- [ ] **Patch** (Public API was unchanged.)
+  - A bug in behavior was fixed.
+  - Documentation was changed.
+- [ ] **None** (The library is unchanged.)
+  - Only code under the `build` folder was changed.
+  - Only code under the `.github` folder was changed.
 
-- [ ] Documentation has been added/updated.
-- [ ] Automated tests for the changes have been added/updated.
-- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).
+## PR Checklist 
 
-<!-- If this PR contains a breaking change, please describe the impact
-     and migration path for existing applications below. -->
+- [ ] Your conventional commits are aligned with the **Impact on version** section.
+- [ ] Documentation is up to date.
+  - Content of `README.md` is up to date.
+  - XML documentation is up to date.
+- [ ] The [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) document is up to date.
+  - Create a new Major.0.0 header if you do a **Major** change and list the breaking changes.
+- [ ] Tested on all relevant platforms
 
 ## Other information
+
 <!-- Please provide any additional information if necessary -->
 
+## Internal Issue (If applicable):
+<!-- Link to relevant internal issue if applicable. All PRs should be associated with an issue (GitHub issue or internal) -->


### PR DESCRIPTION
GitHub Issue: #
<!-- Link to relevant GitHub issue if applicable.
     All PRs should be associated with an issue -->

## Proposed Changes
<!-- Please check one or more that apply to this PR. -->

 - [ ] Bug fix
 - [ ] Feature
 - [ ] Code style update (formatting)
 - [ ] Refactoring (no functional changes, no api changes)
 - [ ] Build or CI related changes
 - [ ] Documentation content changes
 - [x] Other, please describe:


## What is the current behavior?
It's currently the old PR template.

## What is the new behavior?
I'm brining nventive standard PR template.

## Checklist

Please check that your PR fulfills the following requirements:

- [ ] Documentation has been added/updated.
- [ ] Automated tests for the changes have been added/updated.
- [ ] Updated [BREAKING_CHANGES.md](../BREAKING_CHANGES.md) (if you introduced a breaking change).

<!-- If this PR contains a breaking change, please describe the impact
     and migration path for existing applications below. -->

## Other information
<!-- Please provide any additional information if necessary -->

